### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/op-supervisor/supervisor/backend/db/sync/server.go
+++ b/op-supervisor/supervisor/backend/db/sync/server.go
@@ -45,6 +45,9 @@ func NewServer(config Config, chains []eth.ChainID) (*Server, error) {
 		validChains[chain] = struct{}{}
 	}
 
+	// Store the absolute root path back into the config to use as a trusted base directory
+	config.DataDir = root
+
 	return &Server{
 		config:      config,
 		validChains: validChains,
@@ -95,8 +98,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	filePath := filepath.Join(s.config.DataDir, chainID.String(), fileName)
 
+	// Ensure the resolved file path is contained within the configured data directory
+	absFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		s.logError("error resolving file path", err, dbName)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	dataDirWithSep := s.config.DataDir
+	if !strings.HasSuffix(dataDirWithSep, string(os.PathSeparator)) {
+		dataDirWithSep += string(os.PathSeparator)
+	}
+	filePathWithSep := absFilePath
+	if !strings.HasSuffix(filePathWithSep, string(os.PathSeparator)) {
+		filePathWithSep += string(os.PathSeparator)
+	}
+	if !strings.HasPrefix(filePathWithSep, dataDirWithSep) {
+		s.logError("attempt to access file outside of data directory", fmt.Errorf("invalid path %q", absFilePath), dbName)
+		http.Error(w, "file not found", http.StatusNotFound)
+		return
+	}
+
 	// Open the file for reading
-	file, err := os.Open(filePath)
+	file, err := os.Open(absFilePath)
 	if err != nil {
 		s.logError("error opening file", err, dbName)
 		http.Error(w, "file not found", http.StatusNotFound)


### PR DESCRIPTION
Potential fix for [https://github.com/Abuchtela/optimism/security/code-scanning/3](https://github.com/Abuchtela/optimism/security/code-scanning/3)

In general terms, the safest way to fix this is to ensure that any filesystem path derived (even indirectly) from user input is constrained to a known “safe” directory. This is typically done by resolving the candidate path to an absolute path and then checking that it has the safe directory as a prefix. If it does not, we reject the request. This pattern both silences the static analysis warning and protects against any future changes to `eth.ChainID` or other components that might weaken their input validation.

The best concrete fix here, without changing existing functionality or public APIs, is to validate `filePath` just before opening the file. We already have `s.config.DataDir` and `chainID.String()` as components, and we know `config.DataDir` is validated and normalized in `NewServer`. We can:

1. Ensure `s.config.DataDir` is stored as an absolute, cleaned path in `NewServer`, so that later comparisons are reliable.
2. After constructing `filePath` in `ServeHTTP`, compute an absolute, cleaned version of it and verify that it is inside `s.config.DataDir`:
   - `absDataDir := s.config.DataDir` (already absolute from step 1).
   - `absFilePath, err := filepath.Abs(filePath)` and handle errors.
   - Check `strings.HasPrefix(absFilePath+string(os.PathSeparator), absDataDir+string(os.PathSeparator))`. Appending a path separator before comparing prevents false positives where `/data/dir2` would be considered under `/data/dir`.
3. If the check fails, log an error and return `http.StatusBadRequest` or `http.StatusNotFound` without opening the file.

To implement this:

- In `NewServer`, normalize `config.DataDir` to its absolute form before storing it in `Server`. That ensures all subsequent joins are from a known base.
- In `ServeHTTP`, right after computing `filePath := filepath.Join(s.config.DataDir, chainID.String(), fileName)`, add the containment check described above.
- No new imports are needed beyond the existing `os`, `filepath`, and `strings` packages.

This keeps existing behavior for valid requests but adds a robust guardrail and removes the CodeQL warning by clearly validating the path before file access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented strict path validation to prevent unauthorized access to files outside the configured data directory, enhancing security against directory traversal attempts.
  * Improved error handling for path resolution failures and file access operations with more appropriate HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->